### PR TITLE
Support latest analyzer and Dart 3.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,17 +8,16 @@ version: 0.3.1
 homepage: https://github.com/simphotonics/generic_reader
 
 environment:
-  sdk: '>=2.19.0 <3.0.0'
+  sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  analyzer: ^5.4.0
+  analyzer: '>=5.2.0 <7.0.0'
   exception_templates: ^0.2.4
   meta: ^1.9.0
-  source_gen: ^1.2.7
+  source_gen: any
 
 dev_dependencies:
   ansicolor: ^2.0.1
-  dartdoc: ^6.1.5
   lints: ^2.0.1
   source_gen_test: ^1.0.4
   test: ^1.22.2


### PR DESCRIPTION
Support latest analyzer and Dart 3.0
Also drop dartdoc dev dependency, because it is redundant with SDK